### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/linenoise.opam
+++ b/linenoise.opam
@@ -14,7 +14,7 @@ build: [
   ["dune" "build" "@doc" "-p" name] {with-doc}
 ]
 depends: [
-  "dune" {build}
+  "dune"
   "result"
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.