### PR TITLE
Fix multiple definitions of linenoiseWasInterrupted

### DIFF
--- a/src/linenoise_src.h
+++ b/src/linenoise_src.h
@@ -43,7 +43,7 @@
 extern "C" {
 #endif
 
-int linenoiseWasInterrupted; /* boolean signalling if last call was ctrl-c */
+extern int linenoiseWasInterrupted; /* boolean signalling if last call was ctrl-c */
 
 typedef struct linenoiseCompletions {
   size_t len;


### PR DESCRIPTION
The library relied on a non-standard behavior of GCC: When a global was defined multiple times, it is merged. This is control by option `-fcommon`. Starting from GCC 10, this not the default behavior anymore. The default is `-fno-common` that do not merge automatically global variables. This new behavior is compliant with the C standard. In this library the variable `linenoiseWasInterrupted` was defined twice: once in the header and once in a source file. I made the header line a declaration so that there is only a single definition in the source file. 
This library now compiles with GCC 10