### PR TITLE
turn examples/Makefile into a `make example` rule in the toplevel makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,13 @@ build:
 test:
 	@dune runtest --no-buffer --force
 
+example:
+	@dune exec examples/show_off.exe
+
 clean:
 	@dune clean
 
 doc:
 	@dune build @doc
 
+.PHONY: all build test example clean doc

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,8 +1,0 @@
-.PHONY:all
-
-all:
-	@ocamlfind ocamlopt show_off.ml -package linenoise -linkpkg -o T
-	@./T
-
-clean:
-	@rm -rf *.o *.c* T history.txt


### PR DESCRIPTION
I got confused for a moment when implementing the change in #16 : I edited the sources of the library, then saw that `examples/Makefile` existed, so I went to `examples/` and hit `make` to try to test my changes. And that built and run happily enough, but was however using the *system wide* installation of `linenoise` instead of the development copy. 
Instead, I should have run `dune exec examples/show_off.exe`, using dune to properly use the development library instead of using the hand-crafted build rule from `examples/Makefile`.

In this PR I propose to get rid of the error prone `examples/Makefile`, and instead add a `make example` rule in the toplevel makefile to run the example (which is still useful for demo purposes and testing the library).